### PR TITLE
Update invoke.js

### DIFF
--- a/src/lib/invoke.js
+++ b/src/lib/invoke.js
@@ -253,7 +253,7 @@ module.exports = function invoke({
                 }
             })
             .catch((err) => {
-                logger.error(`Failed to invoke successfully: ${JSON.stringify(err)}`);
+                logger.error(`Failed to invoke successfully: ${err}`);
                 reject(err);
             });
     });


### PR DESCRIPTION
Stringifying the error displays {}. Removing the stringify displays the correct error